### PR TITLE
Add recipe for wandboard

### DIFF
--- a/debian/armhf/image-wb/debimage-wb.yaml
+++ b/debian/armhf/image-wb/debimage-wb.yaml
@@ -1,0 +1,87 @@
+{{- $image := or .image "debian-wb.img" -}}
+
+architecture: armhf
+
+actions:
+  - action: debootstrap
+    suite: "buster"
+    components:
+      - main
+    mirror: https://deb.debian.org/debian
+    variant: minbase
+
+  - action: apt
+    packages: [ sudo, openssh-server, adduser, systemd-sysv]
+
+  - action: run
+    chroot: true
+    script: setup-user.sh
+
+  - action: run
+    chroot: true
+    command: echo wandboard > /etc/hostname
+
+  - action: overlay
+    source: networkd
+
+  - action: run
+    chroot: true
+    script: setup-networking.sh
+
+  - action: apt
+    recommends: false
+    packages:
+      - linux-image-armmp
+      - u-boot-imx
+
+  # Note: cma reserves continuous video memory for graphics
+  - action: run
+    chroot: true
+    command: echo console=ttymxc0,115200 quiet cma=256M > /etc/kernel/cmdline
+
+  # Make dtb easy to find (normally flash-kernel does this for us)
+  - action: run
+    chroot: true
+    command: ln -rsf /usr/lib/linux-image-*-armmp/imx6q-wandboard.dtb /boot/dtb
+
+  # generate a boot.scr and put in $ROOTDIR/boot/boot.scr
+  - action: run
+    script: gen-bootscript.sh
+
+  # partition table
+  - action: image-partition
+    imagename: {{ $image }}
+    imagesize: 1GB
+    partitiontype: msdos
+    mountpoints:
+      - mountpoint: /
+        partition: root
+    partitions:
+      - name: root
+        fs: ext4
+        start: 1M
+        end: 100%
+        flags: [ boot ]
+
+  - action: filesystem-deploy
+    description: Deploying filesystem onto image
+
+  # Write u-boot SPL and full version
+  # (note: must be done after partition table writing or will be wiped!)
+  - action: raw
+    origin: filesystem
+    source: /usr/lib/u-boot/wandboard/SPL
+    offset: 1024 # bs=1k seek=1
+
+  - action: raw
+    origin: filesystem
+    source: /usr/lib/u-boot/wandboard/u-boot.img
+    offset: 70656 # bs=1k seek=69
+
+  - action: run
+    postprocess: true
+    command: bmaptool create {{ $image }} > {{ $image }}.bmap
+
+  - action: run
+    postprocess: true
+    command: gzip -f {{ $image }}

--- a/debian/armhf/image-wb/gen-bootscript.sh
+++ b/debian/armhf/image-wb/gen-bootscript.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Puts below info in a script and generate boot.scr
+# This script assumes it's executed from 'artifact directory' (/scratch)
+
+cat << 'EOF' > bootscr.txt
+# debos wandboard boot script
+# loadaddr=0x12000000
+# ramdiskaddr=0x13000000
+# fdt_addr=0x18000000
+# console=ttymxc0,115200
+
+setenv prepbootargs 'if test -n "${console}"; then setenv bootargs "${bootargs} console=${console}" ; fi ; setenv bootargs ${bootargs} cma=256M ; setenv bootargs ${bootargs} root=LABEL=root'
+#setenv bootargs  ${bootargs} quiet
+
+setenv loadkernel 'load mmc 0 ${loadaddr} /vmlinuz'
+setenv loadfdt 'load mmc 0 ${fdt_addr} /boot/dtb'
+setenv loadrd 'load mmc 0 ${ramdiskaddr} /initrd.img && setenv rdsize $filesize'
+setenv loadall 'run loadkernel; run loadfdt; run loadrd'
+
+setenv bootmmc 'mmc dev 0; run prepbootargs; run loadall; bootz ${loadaddr} ${ramdiskaddr}:${rdsize} ${fdt_addr}'
+
+run bootmmc
+
+EOF
+
+mkimage -A arm -T script -C none -n "Debos Wandboard script" -d bootscr.txt $ROOTDIR/boot/boot.scr

--- a/debian/armhf/image-wb/networkd/etc/systemd/network/wired.network
+++ b/debian/armhf/image-wb/networkd/etc/systemd/network/wired.network
@@ -1,0 +1,6 @@
+[Match]
+Name=e*
+
+[Network]
+DHCP=yes
+

--- a/debian/armhf/image-wb/setup-networking.sh
+++ b/debian/armhf/image-wb/setup-networking.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Network management
+systemctl enable systemd-networkd
+# DNS resolving
+systemctl enable systemd-resolved
+# NTP client
+systemctl enable systemd-timesyncd
+
+ln -sf /lib/systemd/resolv.conf /etc/resolv.conf || true

--- a/debian/armhf/image-wb/setup-user.sh
+++ b/debian/armhf/image-wb/setup-user.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+adduser --gecos user \
+  --disabled-password \
+  --shell /bin/bash \
+  user
+adduser user sudo
+echo "user:user" | chpasswd


### PR DESCRIPTION
This uses u-boot and kernel from Debian
(as well as debootstrap minbase rootfs)

Network and user setup is identical to the rpi3 arm64 recipe.