### PR TITLE
rpi3: Use "arm_64bit" instead of "arm_control".

### DIFF
--- a/rpi3/overlays/fw-config/config.txt
+++ b/rpi3/overlays/fw-config/config.txt
@@ -1,3 +1,3 @@
-arm_control=0x200
+arm_64bit=1
 enable_uart=1
 kernel=u-boot.bin


### PR DESCRIPTION
According to [0], ```arm_control``` is deprecated in favor of ```arm_64bit```.

[0] https://www.raspberrypi.org/documentation/configuration/config-txt/misc.md