### PR TITLE
debian/armhf/image-wb/debimage-wb.yaml repair

### DIFF
--- a/debian/armhf/image-wb/debimage-wb.yaml
+++ b/debian/armhf/image-wb/debimage-wb.yaml
@@ -29,9 +29,11 @@ actions:
     script: setup-networking.sh
 
   - action: apt
+    chroot: true
     recommends: false
     packages:
       - linux-image-armmp
+      - u-boot-tools
       - u-boot-imx
 
   # Note: cma reserves continuous video memory for graphics
@@ -46,6 +48,7 @@ actions:
 
   # generate a boot.scr and put in $ROOTDIR/boot/boot.scr
   - action: run
+    chroot: true
     script: gen-bootscript.sh
 
   # partition table


### PR DESCRIPTION
The build error was `mkimage not found`.
Installed it from `u-boot-tools`, but it needs to be in the chroot

Please note: It is now a clean build.  It is NOT verified on actual hardware
(I didn't have access to it when the build errors was (and repaired))