### PR TITLE
[RPi64] Adding missing systemd-timesyncd to package list

### DIFF
--- a/rpi64/debimage-rpi64.yaml
+++ b/rpi64/debimage-rpi64.yaml
@@ -41,6 +41,7 @@ actions:
       - u-boot-menu
       - u-boot-rpi
       - vim-tiny
+      - systemd-timesyncd
 
   - action: overlay
     description: Install U-Boot menu configuration


### PR DESCRIPTION
**Issue:** Building the RPi64 recipe on the master branch fails at the stage `setup-networking.sh`
```text
2022/06/21 08:00:54 ==== run ====
2022/06/21 08:00:55 setup-networking.sh | Created symlink /etc/systemd/system/dbus-org.freedesktop.network1.service → /lib/systemd/system/systemd-networkd.service.
2022/06/21 08:00:55 setup-networking.sh | Created symlink /etc/systemd/system/multi-user.target.wants/systemd-networkd.service → /lib/systemd/system/systemd-networkd.service.
2022/06/21 08:00:55 setup-networking.sh | Created symlink /etc/systemd/system/sockets.target.wants/systemd-networkd.socket → /lib/systemd/system/systemd-networkd.socket.
2022/06/21 08:00:55 setup-networking.sh | Created symlink /etc/systemd/system/network-online.target.wants/systemd-networkd-wait-online.service → /lib/systemd/system/systemd-networkd-wait-online.service.
2022/06/21 08:00:55 setup-networking.sh | Failed to enable unit, unit systemd-timesyncd.service does not exist.
2022/06/21 08:00:55 Action `run` failed at stage Run, error: exit status 1
Powering off.
```

**Reproducing steps:** 
```sh
cd rpi64
docker run --rm --interactive --tty --device /dev/kvm --user $(id -u) -v /dev/shm:/dev/shm --workdir /recipes --mount "type=bind,source=$(pwd),destination=/recipes" --security-opt label=disable godebos/debos -v debimage-rpi64.yaml
```

**Reason:** systemd-timesyncd is not installed on the system hence it cannot be enabled.

**Fix:** Included systemd-timesyncd to the package list
